### PR TITLE
PEP 675: Add exhaustive list of `str` methods that preserve literal types.

### DIFF
--- a/pep-0675.rst
+++ b/pep-0675.rst
@@ -300,6 +300,7 @@ if they evaluate to the same value (``str``), such as
 Type Inference
 ==============
 
+.. _inferring_literal_str:
 
 Inferring ``Literal[str]``
 --------------------------
@@ -326,6 +327,10 @@ following cases:
   if its constituent expressions are literal strings. ``s.format(...)``
   has type ``Literal[str]`` if and only if ``s`` and the arguments have
   types compatible with ``Literal[str]``.
+
++ Literal-preserving methods: In `Appendix C <appendix_C_>`_, we have
+  provided an exhaustive list of ``str`` methods that preserve the
+  ``Literal[str]`` type.
 
 In all other cases, if one or more of the composed values has a
 non-literal type ``str``, the composition of types will have type
@@ -954,6 +959,246 @@ Without ``Literal[str]``, the best enforcement tool API authors have
 is documentation, which is easily ignored and often not seen. With
 ``Literal[str]``, API misuse requires conscious thought and artifacts
 in the code that reviewers and future developers can notice.
+
+.. _appendix_C:
+
+Appendix C: ``str`` methods that preserve ``Literal[str]``
+==========================================================
+
+The ``str`` class has several methods that would benefit from
+``Literal[str]``. For example, users might expect
+``"hello".capitalize()`` to have the type ``Literal[str]`` similar to
+the other examples we have seen in the `Inferring Literal[str] section
+<inferring_literal_str>`_ section. Inferring the type ``Literal[str]``
+is correct because the string is not an arbitrary user-supplied
+string. In other words, the ``capitalize`` method preserves the
+``Literal[str]`` type. There are several other methods that preserve
+the ``Literal[str]``.
+
+We face a tradeoff in this PEP. We could require type checkers to
+preserve ``Literal[str]`` either (a) only for the four cases mentioned
+in the `Inferring Literal[str] section <inferring_literal_str_>`_
+section or (b) for all the ``str`` methods for which it would be
+valid. Option (a) might surprise users by losing the ``Literal[str]``
+type in innocuous uses, e.g., with ``my_literal.capitalize()``. Option
+(b) would be more user-friendly but would require some more work from
+type checkers.
+
+We decided to favor user-friendliness and go with option (b). However,
+if the Steering Council feels the other way, we are willing to go with
+option (a).
+
+Further, we propose updating the stub for ``str`` in typeshed so that
+the methods are overloads with the ``Literal[str]``-preserving
+versions. This means type checkers do not have hardcode
+``Literal[str]`` behavior for each method. This also lets us easily
+support new methods in the future by updating the typeshed stub.
+
+For example, to preserve literal types for the ``capitalize`` method,
+we would change the stub as below:
+
+::
+
+    # before
+    def capitalize(self) -> str: ...
+
+    # after
+    @overload
+    def capitalize(self: Literal[str]) -> Literal[str]: ...
+    @overload
+    def capitalize(self) -> str: ...
+
+The downside of changing ``str`` stub is that the stub becomes more
+complicated and can make error messages harder to understand. Type
+checkers may need to special-case ``str`` so that error messages are
+understandable for users.
+
+If the Steering Council is opposed to this typeshed stub change, we
+will require type checkers to hardcode these methods.
+
+Below is an exhaustive list of ``str`` methods which, when called as
+indicated with ``Literal[str]``(s) must be treated as returning a
+``Literal[str]``. If this PEP is accepted, we will update these method
+signatures in typeshed:
+
+::
+
+    @overload
+    def __new__(cls, object: Literal[str] = ...) -> Literal[str]: ...
+    @overload
+
+    @overload
+    def capitalize(self: Literal[str]) -> Literal[str]: ...
+    @overload
+    def capitalize(self) -> str: ...
+
+    @overload
+    def casefold(self: Literal[str]) -> Literal[str]: ...
+    @overload
+    def casefold(self) -> str: ...
+
+    @overload
+    def center(self: Literal[str], __width: SupportsIndex, __fillchar: Literal[str] = ...) -> Literal[str]: ...
+    @overload
+    def center(self, __width: SupportsIndex, __fillchar: str = ...) -> str: ...
+
+    if sys.version_info >= (3, 8):
+        @overload
+        def expandtabs(self: Literal[str], tabsize: SupportsIndex = ...) -> Literal[str]: ...
+        @overload
+        def expandtabs(self, tabsize: SupportsIndex = ...) -> str: ...
+
+    else:
+        @overload
+        def expandtabs(self: Literal[str], tabsize: int = ...) -> Literal[str]: ...
+        @overload
+        def expandtabs(self, tabsize: int = ...) -> str: ...
+
+    @overload
+    def format(self: Literal[str], *args: Literal[str], **kwargs: Literal[str]) -> Literal[str]: ...
+    @overload
+    def format(self, *args: str, **kwargs: str) -> str: ...
+
+    @overload
+    def format_map(self: Literal[str], map: Mapping[str, Literal[str]]) -> Literal[str]: ...
+    @overload
+    def format_map(self, map: Mapping[str, str]) -> str: ...
+
+    @overload
+    def join(self: Literal[str], __iterable: Iterable[Literal[str]]) -> Literal[str]: ...
+    @overload
+    def join(self, __iterable: Iterable[str]) -> str: ...
+
+    @overload
+    def ljust(self: Literal[str], __width: SupportsIndex, __fillchar: Literal[str] = ...) -> Literal[str]: ...
+    @overload
+    def ljust(self, __width: SupportsIndex, __fillchar: str = ...) -> str: ...
+
+    @overload
+    def lower(self: Literal[str]) -> Literal[str]: ...
+    @overload
+    def lower(self) -> Literal[str]: ...
+
+    @overload
+    def lstrip(self: Literal[str], __chars: Literal[str] | None = ...) -> Literal[str]: ...
+    @overload
+    def lstrip(self, __chars: str | None = ...) -> str: ...
+
+    @overload
+    def partition(self: Literal[str], __sep: Literal[str]) -> tuple[Literal[str], Literal[str], Literal[str]]: ...
+    @overload
+    def partition(self, __sep: str) -> tuple[str, str, str]: ...
+
+    @overload
+    def replace(self: Literal[str], __old: Literal[str], __new: Literal[str], __count: SupportsIndex = ...) -> Literal[str]: ...
+    @overload
+    def replace(self, __old: str, __new: str, __count: SupportsIndex = ...) -> str: ...
+
+    if sys.version_info >= (3, 9):
+        @overload
+        def removeprefix(self: Literal[str], __prefix: Literal[str]) -> Literal[str]: ...
+        @overload
+        def removeprefix(self, __prefix: str) -> str: ...
+
+        @overload
+        def removesuffix(self: Literal[str], __suffix: Literal[str]) -> Literal[str]: ...
+        @overload
+        def removesuffix(self, __suffix: str) -> str: ...
+
+    @overload
+    def rjust(self: Literal[str], __width: SupportsIndex, __fillchar: Literal[str] = ...) -> Literal[str]: ...
+    @overload
+    def rjust(self, __width: SupportsIndex, __fillchar: str = ...) -> str: ...
+
+    @overload
+    def rpartition(self: Literal[str], __sep: Literal[str]) -> tuple[Literal[str], Literal[str], Literal[str]]: ...
+    @overload
+    def rpartition(self, __sep: str) -> tuple[str, str, str]: ...
+
+    @overload
+    def rsplit(self: Literal[str], sep: Literal[str] | None = ..., maxsplit: SupportsIndex = ...) -> list[Literal[str]]: ...
+    @overload
+    def rsplit(self, sep: str | None = ..., maxsplit: SupportsIndex = ...) -> list[str]: ...
+
+    @overload
+    def rstrip(self: Literal[str], __chars: Literal[str] | None = ...) -> Literal[str]: ...
+    @overload
+    def rstrip(self, __chars: str | None = ...) -> str: ...
+
+    @overload
+    def split(self: Literal[str], sep: Literal[str] | None = ..., maxsplit: SupportsIndex = ...) -> list[Literal[str]]: ...
+    @overload
+    def split(self, sep: str | None = ..., maxsplit: SupportsIndex = ...) -> list[str]: ...
+
+    @overload
+    def splitlines(self: Literal[str], keepends: bool = ...) -> list[Literal[str]]: ...
+    @overload
+    def splitlines(self, keepends: bool = ...) -> list[str]: ...
+
+    @overload
+    def strip(self: Literal[str], __chars: Literal[str] | None = ...) -> Literal[str]: ...
+    @overload
+    def strip(self, __chars: str | None = ...) -> str: ...
+
+    @overload
+    def swapcase(self: Literal[str]) -> Literal[str]: ...
+    @overload
+    def swapcase(self) -> str: ...
+
+    @overload
+    def title(self: Literal[str]) -> Literal[str]: ...
+    @overload
+    def title(self) -> str: ...
+
+    @overload
+    def upper(self: Literal[str]) -> Literal[str]: ...
+    @overload
+    def upper(self) -> str: ...
+
+    @overload
+    def zfill(self: Literal[str], __width: SupportsIndex) -> Literal[str]: ...
+    @overload
+    def zfill(self, __width: SupportsIndex) -> str: ...
+
+    @overload
+    def __add__(self: Literal[str], __s: Literal[str]) -> Literal[str]: ...
+    @overload
+    def __add__(self, __s: str) -> str: ...
+
+    @overload
+    def __iter__(self: Literal[str]) -> Iterator[str]: ...
+    @overload
+    def __iter__(self) -> Iterator[str]: ...
+
+    @overload
+    def __mod__(self: Literal[str], __x: Union[Literal[str], Tuple[Literal[str], ...]]) -> str: ...
+    @overload
+    def __mod__(self, __x: Union[str, Tuple[str, ...]]) -> str: ...
+
+    @overload
+    def __mul__(self: Literal[str], __n: SupportsIndex) -> Literal[str]: ...
+    @overload
+    def __mul__(self, __n: SupportsIndex) -> str: ...
+
+    @overload
+    def __repr__(self: Literal[str]) -> Literal[str]: ...
+    @overload
+    def __repr__(self) -> str: ...
+
+    @overload
+    def __rmul__(self: Literal[str], n: SupportsIndex) -> Literal[str]: ...
+    @overload
+    def __rmul__(self, n: SupportsIndex) -> str: ...
+
+    @overload
+    def __str__(self: Literal[str]) -> Literal[str]: ...
+    @overload
+    def __str__(self) -> str: ...
+
+    @overload
+    def __getnewargs__(self: Literal[str]) -> tuple[Literal[str]]: ...
+    @overload
+    def __getnewargs__(self) -> tuple[str]: ...
 
 Resources
 =========


### PR DESCRIPTION
Mostly looking for feedback on the two design choices we need to make:

1. Do we restrict literal-preserving `str` methods to (a) just the four mentioned in "Type Inference" or (b) to the full set of `str` methods?
2. Do we (a) overload the typeshed stubs for those methods or (b) leave the `str` stub as is and ask type checkers to hardcode literal behavior?

cc @gbleaney